### PR TITLE
Reformatted Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install -r requirements.txt .
 
 ### Accessing the LLM Endpoint
 Our end to end script is currently structured to handle requests to the Anthropic sonnet 3.5 model. To send requests to the model,
-set your own api key to `ANTHROPIC_API_KEY`.
+set your own api key to `API_KEY`.
 
 ### Running the Pipeline
 

--- a/end_to_end_script.py
+++ b/end_to_end_script.py
@@ -5,6 +5,7 @@ from absl import flags, app
 import sys
 from pathlib import Path
 import datetime
+from score_scripts.language_suffix import LanguageSuffixHandler
 
 OUTPUT_DIR = "out"
 REPOS_DIR = os.path.join(OUTPUT_DIR, "repos")
@@ -158,9 +159,8 @@ def extract_doc_lines(test_case, data_dir):
         extracted_lines = lines[start_line:end_line +1]
         result = '\n'.join(extracted_lines)
     
-    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
-    out_dir = os.path.join(RESULTS_DIR, f"doc_{datetime.date.today()}", test_case["case_id"])
-    with open(os.path.join(out_dir, f"before_contents{file_type}"), 'w') as f:
+    out_dir = os.path.join(RESULTS_DIR, f"doc_{datetime.date.today()}", test_case["case_id"], f"before_contents{LanguageSuffixHandler(test_case['language']).get()}")
+    with open(out_dir, 'w') as f:
         f.write(result)
     return result
     
@@ -179,10 +179,9 @@ def process_fix(test_case, model_response):
     Returns:
         dict: A dictionary containing the fix evaluation score and related details.
     """
-    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
     
-    out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
-    with open(os.path.join(out_dir, f"after_contents{file_type}"), 'w') as f:
+    out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}", f"after_contents{LanguageSuffixHandler(test_case['language']).get()}")
+    with open(out_dir, 'w') as f:
         json.dump(model_response, f, indent=4)
 
     return fix_score.score_fix(
@@ -209,9 +208,9 @@ def process_test(test_case, model_response):
     Returns:
         dict: A dictionary containing the test evaluation score and related details.
     """
-    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
-    out_dir = os.path.join(RESULTS_DIR, f"test_gen_{datetime.date.today()}", test_case["case_id"])
-    with open(os.path.join(out_dir, f"before_contents{file_type}"), 'w') as f:
+
+    out_dir = os.path.join(RESULTS_DIR, f"test_gen_{datetime.date.today()}", test_case["case_id"], f"before_contents{LanguageSuffixHandler(test_case['language']).get()}")
+    with open(out_dir, 'w') as f:
         f.write(test_case["code_snippet"])
 
     return test_score.score_test(
@@ -238,11 +237,10 @@ def process_doc(test_case, model_response):
 
     Returns:
         dict: A dictionary containing the documentation evaluation score and related details.
-    """
-    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
-    
-    out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
-    with open(os.path.join(out_dir, f"after_contents{file_type}"), 'w') as f:
+    """    
+
+    out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}", f"after_contents{LanguageSuffixHandler(test_case['language']).get()}")
+    with open(out_dir, 'w') as f:
         f.write(model_response)
 
     return doc_score.score_doc(

--- a/end_to_end_script.py
+++ b/end_to_end_script.py
@@ -75,7 +75,7 @@ def evaluate(data_dir, model):
             print("\n Model Response:\n" + model_response)
 
             # Evaluate using specific dir process
-            out_file = os.path.join(RESULTS_DIR, f"{test_case['case_id']}.json")
+            out_file = os.path.join(RESULTS_DIR, f"{FLAGS.metric}-{test_case['case_id']}.json")
             result = process_func(test_case=test_case, model_response=model_response)
             with open(out_file, 'w') as f:
                 json.dump(result, f, indent=4)

--- a/end_to_end_script.py
+++ b/end_to_end_script.py
@@ -75,7 +75,10 @@ def evaluate(data_dir, model):
             print("\n Model Response:\n" + model_response)
 
             # Evaluate using specific dir process
+            
             out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
+            if not os.path.exists(out_dir):
+                os.makedirs(out_dir)
             result = process_func(test_case=test_case, model_response=model_response)
             
             with open(os.path.join(out_dir, "result.json"), 'w') as f:
@@ -171,10 +174,10 @@ def process_fix(test_case, model_response):
         dict: A dictionary containing the fix evaluation score and related details.
     """
     file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
-
-    if not os.path.exists(os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")):
-        os.makedirs(os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}"))
+    
     out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
     with open(os.path.join(out_dir, f"after_contents{file_type}"), 'w') as f:
         json.dump(model_response, f, indent=4)
 
@@ -202,6 +205,14 @@ def process_test(test_case, model_response):
     Returns:
         dict: A dictionary containing the test evaluation score and related details.
     """
+    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
+    
+    out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    with open(os.path.join(out_dir, f"after_contents{file_type}"), 'w') as f:
+        json.dump(model_response, f, indent=4)
+        
     return test_score.score_test(
         base_path=os.path.join(REPOS_DIR, test_case["repo_name"]),
         repo_folder_name=test_case["repo_name"],

--- a/end_to_end_script.py
+++ b/end_to_end_script.py
@@ -156,7 +156,13 @@ def extract_doc_lines(test_case, data_dir):
     with open(file_path, 'r') as file:
         lines = file.readlines()
         extracted_lines = lines[start_line:end_line +1]
-        return '\n'.join(extracted_lines)
+        result = '\n'.join(extracted_lines)
+    
+    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
+    out_dir = os.path.join(RESULTS_DIR, f"doc_{datetime.date.today()}", test_case["case_id"])
+    with open(os.path.join(out_dir, f"before_contents{file_type}"), 'w') as f:
+        f.write(result)
+    return result
     
 def process_fix(test_case, model_response):
     """
@@ -205,20 +211,14 @@ def process_test(test_case, model_response):
     Returns:
         dict: A dictionary containing the test evaluation score and related details.
     """
-    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
-    
-    out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
-    with open(os.path.join(out_dir, f"after_contents{file_type}"), 'w') as f:
-        json.dump(model_response, f, indent=4)
-        
+
     return test_score.score_test(
         base_path=os.path.join(REPOS_DIR, test_case["repo_name"]),
         repo_folder_name=test_case["repo_name"],
         relative_path=Path(test_case["file_path"]),
         language=test_case["language"],
-        model_response=model_response
+        model_response=model_response,
+        case_id=test_case["case_id"]
     )
     
 def process_doc(test_case, model_response):

--- a/end_to_end_script.py
+++ b/end_to_end_script.py
@@ -211,6 +211,10 @@ def process_test(test_case, model_response):
     Returns:
         dict: A dictionary containing the test evaluation score and related details.
     """
+    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
+    out_dir = os.path.join(RESULTS_DIR, f"test_gen_{datetime.date.today()}", test_case["case_id"])
+    with open(os.path.join(out_dir, f"before_contents{file_type}"), 'w') as f:
+        f.write(test_case["code_snippet"])
 
     return test_score.score_test(
         base_path=os.path.join(REPOS_DIR, test_case["repo_name"]),

--- a/end_to_end_script.py
+++ b/end_to_end_script.py
@@ -66,6 +66,9 @@ def evaluate(data_dir, model):
         if processed_cases >= FLAGS.n_cases:
             break
         if test_case["language"] in languages:
+            out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
+            if not os.path.exists(out_dir):
+                os.makedirs(out_dir)
 
             # Get response from model
             model_input = create_model_input(test_case, data_dir)
@@ -76,9 +79,6 @@ def evaluate(data_dir, model):
 
             # Evaluate using specific dir process
             
-            out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
-            if not os.path.exists(out_dir):
-                os.makedirs(out_dir)
             result = process_func(test_case=test_case, model_response=model_response)
             
             with open(os.path.join(out_dir, "result.json"), 'w') as f:
@@ -182,8 +182,6 @@ def process_fix(test_case, model_response):
     file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
     
     out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
     with open(os.path.join(out_dir, f"after_contents{file_type}"), 'w') as f:
         json.dump(model_response, f, indent=4)
 
@@ -241,6 +239,12 @@ def process_doc(test_case, model_response):
     Returns:
         dict: A dictionary containing the documentation evaluation score and related details.
     """
+    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[test_case["language"]]
+    
+    out_dir = os.path.join(RESULTS_DIR, f"{FLAGS.metric}_{datetime.date.today()}", f"{test_case['case_id']}")
+    with open(os.path.join(out_dir, f"after_contents{file_type}"), 'w') as f:
+        f.write(model_response)
+
     return doc_score.score_doc(
         base_path=base_path,
         start_line=test_case["line_range"][0],

--- a/end_to_end_script.py
+++ b/end_to_end_script.py
@@ -184,7 +184,8 @@ def process_fix(test_case, model_response):
         relative_path=Path(test_case["file_path"]), 
         task=test_case["command_specific_fields"]["static_analyzer"],
         language=test_case["language"], 
-        model_response=model_response
+        model_response=model_response,
+        case_id=test_case["case_id"]
     )
 
 def process_test(test_case, model_response):

--- a/score_scripts/fix_score.py
+++ b/score_scripts/fix_score.py
@@ -12,6 +12,7 @@ from score_scripts.static_analysis_tools import (
     get_tool_run_fn,
 )
 import datetime
+from score_scripts.language_suffix import LanguageSuffixHandler
 
 OUTPUT_DIR = "out"
 REPOS_DIR = os.path.join(OUTPUT_DIR, "repos")
@@ -133,9 +134,8 @@ def score_fix(base_path: Path, repo_name: str, relative_path: Path, model_respon
     input_source_file_path = repo_folder / relative_path
     input_source_file_contents = input_source_file_path.read_text()
 
-    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[language]
-    out_dir = os.path.join(RESULTS_DIR, f"fix_{datetime.date.today()}", case_id)
-    with open(os.path.join(out_dir, f"before_contents{file_type}"), 'w') as f:
+    out_dir = os.path.join(RESULTS_DIR, f"fix_{datetime.date.today()}", case_id, f"before_contents{LanguageSuffixHandler(language).get()}")
+    with open(out_dir, 'w') as f:
         f.write(input_source_file_contents)
 
     score, reason, before_errors, after_errors = evaluate_fix_with_tool(

--- a/score_scripts/fix_score.py
+++ b/score_scripts/fix_score.py
@@ -1,4 +1,6 @@
 import json
+import os
+import re
 from pathlib import Path
 from typing import Dict, Any, List, Tuple
 import difflib
@@ -9,6 +11,11 @@ from score_scripts.static_analysis_tools import (
     get_supported_tools,
     get_tool_run_fn,
 )
+import datetime
+
+OUTPUT_DIR = "out"
+REPOS_DIR = os.path.join(OUTPUT_DIR, "repos")
+RESULTS_DIR = os.path.join(OUTPUT_DIR, "results")
 
 def evaluate_fix_with_tool(
         tool: str,
@@ -77,7 +84,7 @@ def evaluate_fix_with_tool(
 
         return score, reason, before_results or [], after_results or [tool_raw_output]
 
-def score_fix(base_path: Path, repo_name: str, relative_path: Path, model_response: str, task: str, language: str) -> Dict[str, Any]:
+def score_fix(base_path: Path, repo_name: str, relative_path: Path, model_response: str, task: str, language: str, case_id: str) -> Dict[str, Any]:
     """Score the effectiveness of a fix applied to a source file using a specified static analysis tool.
 
     This function evaluates the quality of a fix by running a static analysis tool on the original and modified
@@ -125,6 +132,11 @@ def score_fix(base_path: Path, repo_name: str, relative_path: Path, model_respon
 
     input_source_file_path = repo_folder / relative_path
     input_source_file_contents = input_source_file_path.read_text()
+
+    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[language]
+    out_dir = os.path.join(RESULTS_DIR, f"fix_{datetime.date.today()}", case_id)
+    with open(os.path.join(out_dir, f"before_contents{file_type}"), 'w') as f:
+        f.write(input_source_file_contents)
 
     score, reason, before_errors, after_errors = evaluate_fix_with_tool(
         tool=task,

--- a/score_scripts/language_suffix.py
+++ b/score_scripts/language_suffix.py
@@ -1,0 +1,15 @@
+class LanguageSuffixHandler():
+    """
+    Abstract base class to handle the logic for determining file types
+    based on the language.
+    """
+    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}
+
+    def __init__(self, language: str):
+        self.language = language
+    
+    def get(self) -> str:
+        """
+        Return the file type based on the language.
+        """
+        return self.file_type.get(self.language, "")

--- a/score_scripts/test_score.py
+++ b/score_scripts/test_score.py
@@ -7,6 +7,7 @@ from plum.environments import Repository
 from plum.environments.js_repo import JavascriptRepository
 from plum.actions import Actions
 import datetime
+from score_scripts.language_suffix import LanguageSuffixHandler
 
 OUTPUT_DIR = "out"
 REPOS_DIR = os.path.join(OUTPUT_DIR, "repos")
@@ -156,12 +157,8 @@ def evaluate_generated_test(
 def score_test(base_path: Path, repo_folder_name: str, relative_path: Path, language: str, model_response: str, case_id: str) -> Dict[str, Any]:
     generated_test = get_code_from_outcome(model_response, language)
 
-    file_type = {"python": ".py", "java": ".java", "javascript": ".js", "typescript": ".ts", "csharp": ".cs"}[language]
-
-    out_dir = os.path.join(RESULTS_DIR, f"test_gen_{datetime.date.today()}", f"{case_id}")
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
-    with open(os.path.join(out_dir, f"after_contents{file_type}"), 'w') as f:
+    out_dir = os.path.join(RESULTS_DIR, f"test_gen_{datetime.date.today()}", f"{case_id}", f"after_contents{LanguageSuffixHandler(language).get()}")
+    with open(out_dir, 'w') as f:
         f.write(generated_test)
 
     if generated_test is None:


### PR DESCRIPTION
Reformatted results to /out/results/{metric}_{date}/result.json
Added /out/results/{metric}_{date}/before_contents.json and /out/results/{metric}_{date}/after_contents.json to all metrics for input+output visibility